### PR TITLE
Specify generics on Reduce

### DIFF
--- a/PublicReducer
+++ b/PublicReducer
@@ -14,7 +14,7 @@ public struct <#ReducerName#>: ReducerProtocol {
     
     // MARK: - Reducer Body
     public var body: some ReducerProtocol<State, Action> {
-        Reduce { state, action in
+        Reduce<State, Action> { state, action in
             switch action {
             default:
                 return .none


### PR DESCRIPTION
If the body of `Reduce { ... }` gets moderately complex Swift can stop showing autocomplete and sometimes even warnings. Specifying these generics helps, and since you are generating this code anyway might as well do it from the beginning.